### PR TITLE
Fixed shebang lines

### DIFF
--- a/Examples/dbus-recognized.py
+++ b/Examples/dbus-recognized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 """Run this to see all commands that go through LiSpeak
 """
 import gobject

--- a/Examples/dbus-recognized.py
+++ b/Examples/dbus-recognized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Run this to see all commands that go through LiSpeak
 """
 import gobject

--- a/Microphone/browser.py
+++ b/Microphone/browser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk

--- a/Microphone/browser.py
+++ b/Microphone/browser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk

--- a/Microphone/indicator_server.py
+++ b/Microphone/indicator_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 #
 # Applet in system tray

--- a/Microphone/indicator_server.py
+++ b/Microphone/indicator_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Applet in system tray

--- a/Microphone/notify.py
+++ b/Microphone/notify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 # -*- coding: utf-8 -*-
 import urllib2,sys,time,os,lispeak,json,dbus,dbus.service,getpass

--- a/Microphone/notify.py
+++ b/Microphone/notify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # -*- coding: utf-8 -*-
 import urllib2,sys,time,os,lispeak,json,dbus,dbus.service,getpass

--- a/Microphone/settings.py
+++ b/Microphone/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*- 
 
 from gi.repository import Gtk

--- a/Microphone/settings.py
+++ b/Microphone/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*- 
 
 from gi.repository import Gtk

--- a/Recognition/recognized.py
+++ b/Recognition/recognized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 #
 # Usage: recognized <speech> <command>

--- a/Recognition/recognized.py
+++ b/Recognition/recognized.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Usage: recognized <speech> <command>

--- a/Setup/continue.service
+++ b/Setup/continue.service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # 
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/Setup/continue.service
+++ b/Setup/continue.service
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # 
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/Setup/defaults/bin/UserInformation
+++ b/Setup/defaults/bin/UserInformation
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import argparse, os, subprocess,lispeak,urllib
 argparser = argparse.ArgumentParser(description='Display User Information')
 argparser.add_argument('action', type=str,help='Action to execute')

--- a/Setup/defaults/bin/UserInformation
+++ b/Setup/defaults/bin/UserInformation
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 import argparse, os, subprocess,lispeak,urllib
 argparser = argparse.ArgumentParser(description='Display User Information')
 argparser.add_argument('action', type=str,help='Action to execute')

--- a/Setup/defaults/bin/battery
+++ b/Setup/defaults/bin/battery
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 import lispeak
 
 import dbus

--- a/Setup/defaults/bin/battery
+++ b/Setup/defaults/bin/battery
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 import lispeak
 
 import dbus

--- a/Setup/defaults/bin/brightness
+++ b/Setup/defaults/bin/brightness
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 from sys import argv
 
 args = argv

--- a/Setup/defaults/bin/brightness
+++ b/Setup/defaults/bin/brightness
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 from sys import argv
 
 args = argv

--- a/Setup/defaults/bin/date
+++ b/Setup/defaults/bin/date
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import time,sys
 import lispeak

--- a/Setup/defaults/bin/date
+++ b/Setup/defaults/bin/date
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import time,sys
 import lispeak

--- a/Setup/defaults/bin/mediaAdv
+++ b/Setup/defaults/bin/mediaAdv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import dbus,lispeak
 bus = dbus.SessionBus()

--- a/Setup/defaults/bin/mediaAdv
+++ b/Setup/defaults/bin/mediaAdv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import dbus,lispeak
 bus = dbus.SessionBus()

--- a/Setup/defaults/bin/read
+++ b/Setup/defaults/bin/read
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import lispeak,os,time
 from gi.repository import Gtk, Gdk

--- a/Setup/defaults/bin/read
+++ b/Setup/defaults/bin/read
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import lispeak,os,time
 from gi.repository import Gtk, Gdk

--- a/Setup/defaults/bin/result
+++ b/Setup/defaults/bin/result
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import lispeak,sys
 if "--translate" in sys.argv:

--- a/Setup/defaults/bin/result
+++ b/Setup/defaults/bin/result
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import lispeak,sys
 if "--translate" in sys.argv:

--- a/Setup/defaults/bin/result_from_call
+++ b/Setup/defaults/bin/result_from_call
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # This module can accept many arguments. If the "" syntax is used, then the argument will be recognised as one,
 # else if no "" syntax is used, then the arguments will be recognised as different.
 # I did this to keep a steady syntax across all dictionaries

--- a/Setup/defaults/bin/result_from_call
+++ b/Setup/defaults/bin/result_from_call
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # This module can accept many arguments. If the "" syntax is used, then the argument will be recognised as one,
 # else if no "" syntax is used, then the arguments will be recognised as different.
 # I did this to keep a steady syntax across all dictionaries

--- a/Setup/defaults/bin/say
+++ b/Setup/defaults/bin/say
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import lispeak,sys
 

--- a/Setup/defaults/bin/say
+++ b/Setup/defaults/bin/say
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import lispeak,sys
 

--- a/Setup/defaults/bin/wap.py
+++ b/Setup/defaults/bin/wap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 # Copyright 2009 Derik Pereira. All Rights Reserved.
 #

--- a/Setup/defaults/bin/wap.py
+++ b/Setup/defaults/bin/wap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 #
 # Copyright 2009 Derik Pereira. All Rights Reserved.
 #

--- a/Setup/defaults/bin/weather
+++ b/Setup/defaults/bin/weather
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import urllib,urllib2,sys,time,lispeak
 from HTMLParser import HTMLParser

--- a/Setup/defaults/bin/weather
+++ b/Setup/defaults/bin/weather
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import urllib,urllib2,sys,time,lispeak
 from HTMLParser import HTMLParser

--- a/Setup/defaults/bin/wolf
+++ b/Setup/defaults/bin/wolf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import lispeak,sys,urllib2,getpass,os
 

--- a/Setup/defaults/bin/wolf
+++ b/Setup/defaults/bin/wolf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import lispeak,sys,urllib2,getpass,os
 

--- a/Setup/defaults/bin/xType
+++ b/Setup/defaults/bin/xType
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys,os
 

--- a/Setup/defaults/bin/xType
+++ b/Setup/defaults/bin/xType
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 import sys,os
 

--- a/Setup/libraries/goslate.py
+++ b/Setup/libraries/goslate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 '''Goslate: Free Google Translate API

--- a/Setup/libraries/goslate.py
+++ b/Setup/libraries/goslate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
 '''Goslate: Free Google Translate API

--- a/lispeak
+++ b/lispeak
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*- 
 VERSION = 1.2
 

--- a/lispeak
+++ b/lispeak
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*- 
 VERSION = 1.2
 

--- a/pyrecognize
+++ b/pyrecognize
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 import sys
 import urllib2
 import json


### PR DESCRIPTION
I've fixed the shebang lines due to the fact that LiSpeak wouldn't work
at all on systems that had python 3 set as their default python. This
includes, but is not limited to, Arch Linux.

Looking at the commit in the merge view, I have no idea why my editor decided to add that extra newline in wap.py.